### PR TITLE
Comments out old and "too new" migrations

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
@@ -98,36 +98,36 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 	public HapiFhirJpaMigrationTasks(Set<String> theFlags) {
 		myFlags = theFlags.stream().map(FlagEnum::fromCommandLineValue).collect(Collectors.toSet());
 
-		init330(); // 20180114 - 20180329
-		init340(); // 20180401 - 20180528
-		init350(); // 20180601 - 20180917
-		init360(); // 20180918 - 20181112
-		init400(); // 20190401 - 20190814
-		init410(); // 20190815 - 20191014
-		init420(); // 20191015 - 20200217
-		init430(); // Replaced by 5.0.0
-		init500(); // 20200218 - 20200513
-		init501(); // 20200514 - 20200515
-		init510(); // 20200516 - 20201028
-		init520(); // 20201029 -
-		init530();
-		init540(); // 20210218 - 20210520
-		init550(); // 20210520 -
-		init560(); // 20211027 -
-		init570(); // 20211102 -
-		init600(); // 20211102 -
-		init610();
-		init620();
-		init640();
-		init640_after_20230126();
-		init660();
-		init680();
+		// init330(); // 20180114 - 20180329
+		// init340(); // 20180401 - 20180528
+		// init350(); // 20180601 - 20180917
+		// init360(); // 20180918 - 20181112
+		// init400(); // 20190401 - 20190814
+		// init410(); // 20190815 - 20191014
+		// init420(); // 20191015 - 20200217
+		// init430(); // Replaced by 5.0.0
+		// init500(); // 20200218 - 20200513
+		// init501(); // 20200514 - 20200515
+		// init510(); // 20200516 - 20201028
+		// init520(); // 20201029 -
+		// init530();
+		// init540(); // 20210218 - 20210520
+		// init550(); // 20210520 -
+		// init560(); // 20211027 -
+		// init570(); // 20211102 -
+		// init600(); // 20211102 -
+		// init610();
+		// init620();
+		// init640();
+		// init640_after_20230126();
+		// init660();
+		// init680();
 		init680_Part2();
 		init700();
 		init720();
 		init740();
-		init760();
-		init780();
+		// init760();
+		// init780();
 	}
 
 	protected void init780() {


### PR DESCRIPTION
**Overview**

- This comments out migrations that are for versions prior to v6.10 and new migrations for unreleased new versions (i.e. > v7.6.0)

To run database migrations of our v6.10.x servers to v7.4.0 and/or v7.6.0, we need to run the `hapi-fhir-cli migrate-database` command. The problem is that this command runs VERY OLD and TOO NEW migrations. The documentation states that the `--skip-versions` argument should be used in these cases, but the number of migration tasks to skip is too large for a reasonable command.

To test our migrations, I pulled the open-source repo and commented-out these lines and then built the `hapi-fhir-cli`. To ensure that others can do the same, I forked the repo and submitted this pull request.

I'll continue to research a better method to run the appropriate set of migration tasks and hope to deprecate the use of this fork in the future.

**How it was tested**

- Built and ran unit tests
- Created a local hapi-fhir server using v7.6.0 and started it to create an empty schema, then exported the schema DDL
- Created a local hapi-fhir server using v6.10.1 and started it to create an empty schema, then exported the schema DDL
- Ran the `hapi-fhir-cli migrate-database` command on the v6.10.1 schema
- Compared the v7.6.0 schema DDL to the now-migrated v6.10.1 schema to ensure the migration was successful

**Checklist**

- [x] The title contains a short meaningful summary
- [x]  I have added a link to this PR in the Jira issue
- [x]  I have described how this was tested
- [ ]  I have included screen shots for changes that affect the user interface
- [ ]  I have updated unit tests
- [x]  I have run unit tests locally
- [ ]  I have updated documentation (including README)